### PR TITLE
Add preference to toggle collapsing composer buttons

### DIFF
--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -98,6 +98,7 @@ interface IState {
     isMenuOpen: boolean;
     isStickerPickerOpen: boolean;
     showStickersButton: boolean;
+    collapseButtons: boolean;
 }
 
 @replaceableComponent("views.rooms.MessageComposer")
@@ -128,11 +129,13 @@ export default class MessageComposer extends React.Component<IProps, IState> {
             isMenuOpen: false,
             isStickerPickerOpen: false,
             showStickersButton: SettingsStore.getValue("MessageComposerInput.showStickersButton"),
+            collapseButtons: SettingsStore.getValue("MessageComposerInput.collapseButtons"),
         };
 
         this.instanceId = instanceCount++;
 
         SettingsStore.monitorSetting("MessageComposerInput.showStickersButton", null);
+        SettingsStore.monitorSetting("MessageComposerInput.collapseButtons", null);
     }
 
     componentDidMount() {
@@ -175,6 +178,13 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                         const showStickersButton = SettingsStore.getValue("MessageComposerInput.showStickersButton");
                         if (this.state.showStickersButton !== showStickersButton) {
                             this.setState({ showStickersButton });
+                        }
+                        break;
+                    }
+                    case "MessageComposerInput.collapseButtons": {
+                        const collapseButtons = SettingsStore.getValue("MessageComposerInput.collapseButtons");
+                        if (this.state.collapseButtons !== collapseButtons) {
+                            this.setState({ collapseButtons });
                         }
                         break;
                     }
@@ -464,6 +474,7 @@ export default class MessageComposer extends React.Component<IProps, IState> {
                             setStickerPickerOpen={this.setStickerPickerOpen}
                             showLocationButton={!window.electron}
                             showStickersButton={this.state.showStickersButton}
+                            collapseButtons={this.state.collapseButtons}
                             toggleButtonMenu={this.toggleButtonMenu}
                         /> }
                         { showSendButton && (

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -50,6 +50,7 @@ interface IProps {
     setStickerPickerOpen: (isStickerPickerOpen: boolean) => void;
     showLocationButton: boolean;
     showStickersButton: boolean;
+    collapseButtons: boolean;
     toggleButtonMenu: () => void;
 }
 
@@ -77,7 +78,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
             pollButton(room, props.relation),
             showLocationButton(props, room, roomId, matrixClient),
         ];
-    } else {
+    } else if (props.collapseButtons) {
         mainButtons = [
             emojiButton(props),
             uploadButton(props, roomId),
@@ -88,6 +89,16 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
             pollButton(room, props.relation),
             showLocationButton(props, room, roomId, matrixClient),
         ];
+    } else {
+        mainButtons = [
+            emojiButton(props),
+            uploadButton(props, roomId),
+            showStickersButton(props),
+            voiceRecordingButton(props),
+            pollButton(room, props.relation),
+            showLocationButton(props, room, roomId, matrixClient),
+        ];
+        moreButtons = [];
     }
 
     mainButtons = mainButtons.filter((x: ReactElement) => x);
@@ -101,22 +112,26 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
 
     return <>
         { mainButtons }
-        <AccessibleTooltipButton
-            className={moreOptionsClasses}
-            onClick={props.toggleButtonMenu}
-            title={_t("More options")}
-        />
-        { props.isMenuOpen && (
-            <ContextMenu
-                onFinished={props.toggleButtonMenu}
-                {...props.menuPosition}
-                wrapperClassName="mx_MessageComposer_Menu"
-            >
-                <OverflowMenuContext.Provider value={props.toggleButtonMenu}>
-                    { moreButtons }
-                </OverflowMenuContext.Provider>
-            </ContextMenu>
-        ) }
+        { moreButtons.length > 0 &&
+            <>
+                <AccessibleTooltipButton
+                    className={moreOptionsClasses}
+                    onClick={props.toggleButtonMenu}
+                    title={_t("More options")}
+                />
+                { props.isMenuOpen && (
+                    <ContextMenu
+                        onFinished={props.toggleButtonMenu}
+                        {...props.menuPosition}
+                        wrapperClassName="mx_MessageComposer_Menu"
+                    >
+                        <OverflowMenuContext.Provider value={props.toggleButtonMenu}>
+                            { moreButtons }
+                        </OverflowMenuContext.Provider>
+                    </ContextMenu>
+                ) }
+            </>
+        }
     </>;
 };
 

--- a/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/PreferencesUserSettingsTab.tsx
@@ -162,6 +162,7 @@ export default class PreferencesUserSettingsTab extends React.Component<IProps, 
         'MessageComposerInput.ctrlEnterToSend',
         'MessageComposerInput.surroundWith',
         'MessageComposerInput.showStickersButton',
+        'MessageComposerInput.collapseButtons',
     ];
 
     static TIME_SETTINGS = [

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -905,6 +905,7 @@
     "Use custom size": "Use custom size",
     "Enable Emoji suggestions while typing": "Enable Emoji suggestions while typing",
     "Show stickers button": "Show stickers button",
+    "Collapse additional buttons": "Collapse additional buttons",
     "Use a more compact 'Modern' layout": "Use a more compact 'Modern' layout",
     "Show a placeholder for removed messages": "Show a placeholder for removed messages",
     "Show join/leave messages (invites/removes/bans unaffected)": "Show join/leave messages (invites/removes/bans unaffected)",

--- a/src/settings/Settings.tsx
+++ b/src/settings/Settings.tsx
@@ -422,6 +422,12 @@ export const SETTINGS: {[setting: string]: ISetting} = {
         default: true,
         controller: new UIFeatureController(UIFeature.Widgets, false),
     },
+    "MessageComposerInput.collapseButtons": {
+        supportedLevels: LEVELS_ACCOUNT_SETTINGS,
+        displayName: _td('Collapse additional buttons'),
+        default: true,
+        controller: new UIFeatureController(UIFeature.Widgets, false),
+    },
     // TODO: Wire up appropriately to UI (FTUE notifications)
     "Notifications.alwaysShowBadgeCounts": {
         supportedLevels: LEVELS_ROOM_OR_ACCOUNT,

--- a/test/components/views/rooms/MessageComposerButtons-test.tsx
+++ b/test/components/views/rooms/MessageComposerButtons-test.tsx
@@ -41,6 +41,29 @@ describe("MessageComposerButtons", () => {
                 narrowMode={false}
                 showLocationButton={true}
                 showStickersButton={true}
+                collapseButtons={false}
+                toggleButtonMenu={() => {}}
+            />,
+        );
+
+        expect(buttonLabels(buttons)).toEqual([
+            "Emoji",
+            "Attachment",
+            "Sticker",
+            "Voice Message",
+            "Poll",
+            "Location",
+        ]);
+    });
+
+    it("Renders emoji and upload buttons in wide mode, and collapse additional", () => {
+        const buttons = wrapAndRender(
+            <MessageComposerButtons
+                isMenuOpen={false}
+                narrowMode={false}
+                showLocationButton={true}
+                showStickersButton={true}
+                collapseButtons={true}
                 toggleButtonMenu={() => {}}
             />,
         );
@@ -59,6 +82,7 @@ describe("MessageComposerButtons", () => {
                 narrowMode={false}
                 showLocationButton={true}
                 showStickersButton={true}
+                collapseButtons={true}
                 toggleButtonMenu={() => {}}
             />,
         );


### PR DESCRIPTION
We recently added the function to collapse extra buttons in the composer menu.
This PR adds the option to disable collapsing, and show all buttons in the
composer.  In narrow mode the behavior is not changed.

Fixes: https://github.com/vector-im/element-web/issues/20887

<!-- Please read https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md before submitting your pull request -->

<!-- Include a Sign-Off as described in https://github.com/matrix-org/matrix-js-sdk/blob/develop/CONTRIBUTING.md#sign-off -->

Signed-off-by: Andrew Ryan <andrewryanchama@clover.club>

<!-- To specify text for the changelog entry (otherwise the PR title will be used):
Notes:

Changes in this project generate changelog entries in element-web by default.
To suppress this:

element-web notes: none

...or to specify different notes:
element-web notes: <notes>
-->
<img width="998" alt="Screen Shot 2022-02-18 at 7 09 08 PM" src="https://user-images.githubusercontent.com/89478935/154783860-98dd317e-9437-4ce2-b406-d883c4810dfa.png">
<img width="652" alt="Screen Shot 2022-02-18 at 7 08 55 PM" src="https://user-images.githubusercontent.com/89478935/154783862-314de7ed-b8f0-4c70-bb0d-3659f0b8d413.png">
<img width="1003" alt="Screen Shot 2022-02-18 at 7 08 02 PM" src="https://user-images.githubusercontent.com/89478935/154783863-23046e25-22ec-47c1-bd51-cfc1dc4b032a.png">


---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->

<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->