### PR TITLE
Re-enable the ability to toggle the 'home' metaspace

### DIFF
--- a/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
+++ b/src/components/views/settings/tabs/user/SidebarUserSettingsTab.tsx
@@ -67,12 +67,11 @@ const SidebarUserSettingsTab = () => {
                     checked={!!homeEnabled}
                     onChange={onMetaSpaceChangeFactory(MetaSpace.Home, "WebSettingsSidebarTabSpacesCheckbox")}
                     className="mx_SidebarUserSettingsTab_homeCheckbox"
-                    disabled={homeEnabled}
                 >
                     { _t("Home") }
                 </StyledCheckbox>
                 <div className="mx_SidebarUserSettingsTab_checkboxMicrocopy">
-                    { _t("Home is useful for getting an overview of everything.") }
+                    { _t("Home is useful for getting an overview of everything. Keep in mind that disabling it could leave you unable to see certain rooms.") }
                 </div>
 
                 <StyledCheckbox


### PR DESCRIPTION
**Big important warning: Due to OpenSSL issues, I was not able to get the build environment functional on my system. This is a two-line change. Someone please test this. **

Useful for people who want SchildiChat to act more like other chat platforms (i.e. by having just People and Other meta-spaces)

Commit 4540cf5b77067e2aa0aa8735e53ea179719e22b5 disabled the ability to turn the Home meta-space on/off for... *some reason*.

A sign-off has been included in the commit.


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->