### PR TITLE
Display custom emojis big

### DIFF
--- a/res/css/views/elements/_RichText.scss
+++ b/res/css/views/elements/_RichText.scss
@@ -42,3 +42,13 @@
     font-size: max($font-18px, 1em);
     vertical-align: bottom;
 }
+
+// same for custom emojis 
+img[data-mx-emoticon] {
+    // Should be 1.8rem for our default 1.4rem message bodies,
+    // and scale with the size of the surrounding text
+    max-height: unset !important;
+    height: calc(18 / 14 * 1em) !important;
+    vertical-align: bottom;
+    object-position: center;
+}


### PR DESCRIPTION
Messages with only emojis are displayed bigger.  This change updates
it to extend this behavior for custom emojis as well.

This also fixes the custom emoji css that got lost due to the upstream
changes.

<!-- Please describe your awesome changes here -->

-----------------------------------------------------------------------------

- [x] I agree to release my changes under this project's license


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->