### PR TITLE
Add an emoji picker

### DIFF
--- a/res/css/views/emojipicker/_EmojiPicker.scss
+++ b/res/css/views/emojipicker/_EmojiPicker.scss
@@ -34,6 +34,8 @@ limitations under the License.
 .mx_EmojiPicker_header {
     padding: 4px 8px 0;
     border-bottom: 1px solid $message-action-bar-border-color;
+    white-space: nowrap;
+    overflow: hidden;
 }
 
 .mx_EmojiPicker_anchor {
@@ -56,7 +58,7 @@ limitations under the License.
     }
 }
 
-.mx_EmojiPicker_anchor::before {
+.mx_EmojiPicker_anchor:not(.mx_CustomEmojiCategory)::before {
     background-color: $primary-content;
     content: '';
     display: inline-block;
@@ -66,7 +68,7 @@ limitations under the License.
     height: 100%;
 }
 
-.mx_EmojiPicker_anchor:disabled::before {
+.mx_EmojiPicker_anchor:disabled:not(.mx_CustomEmojiCategory)::before {
     background-color: $focus-bg-color;
 }
 
@@ -226,4 +228,23 @@ limitations under the License.
 
 .mx_EmojiPicker_quick_header .mx_EmojiPicker_name {
     margin-right: 4px;
+}
+
+.mx_customEmoji_image {
+    object-fit: contain;
+    aspect-ratio: 1;
+    vertical-align: top;
+    background-color: $background;
+    width: 24px;
+    height: 24px;
+}
+
+.mx_CustomEmojiCategory {
+    vertical-align: top;
+
+    img {
+        display: inline-block;
+        width: 100%;
+        height: 100%;
+    }
 }

--- a/src/components/views/emojipicker/Category.tsx
+++ b/src/components/views/emojipicker/Category.tsx
@@ -21,14 +21,16 @@ import { CATEGORY_HEADER_HEIGHT, EMOJI_HEIGHT, EMOJIS_PER_ROW } from "./EmojiPic
 import LazyRenderList from "../elements/LazyRenderList";
 import { DATA_BY_CATEGORY, IEmoji } from "../../../emoji";
 import Emoji from './Emoji';
+import { ICustomEmoji } from '../../../emojipicker/customemoji';
 
 const OVERFLOW_ROWS = 3;
 
-export type CategoryKey = (keyof typeof DATA_BY_CATEGORY) | "recent";
+export type CategoryKey = (keyof typeof DATA_BY_CATEGORY) | "recent" | "room";
 
 export interface ICategory {
     id: CategoryKey;
     name: string;
+    representativeEmoji?: ICustomEmoji;
     enabled: boolean;
     visible: boolean;
     ref: RefObject<HTMLButtonElement>;
@@ -37,14 +39,14 @@ export interface ICategory {
 interface IProps {
     id: string;
     name: string;
-    emojis: IEmoji[];
+    emojis: Array<IEmoji | ICustomEmoji>;
     selectedEmojis: Set<string>;
     heightBefore: number;
     viewportHeight: number;
     scrollTop: number;
-    onClick(emoji: IEmoji): void;
-    onMouseEnter(emoji: IEmoji): void;
-    onMouseLeave(emoji: IEmoji): void;
+    onClick(emoji: IEmoji | ICustomEmoji): void;
+    onMouseEnter(emoji: IEmoji | ICustomEmoji): void;
+    onMouseLeave(emoji: IEmoji | ICustomEmoji): void;
 }
 
 class Category extends React.PureComponent<IProps> {
@@ -54,7 +56,7 @@ class Category extends React.PureComponent<IProps> {
         return (<div key={rowIndex}>{
             emojisForRow.map(emoji => (
                 <Emoji
-                    key={emoji.hexcode}
+                    key={'hexcode' in emoji ? emoji.hexcode : emoji.shortcodes[0]}
                     emoji={emoji}
                     selectedEmojis={selectedEmojis}
                     onClick={onClick}

--- a/src/components/views/emojipicker/Emoji.tsx
+++ b/src/components/views/emojipicker/Emoji.tsx
@@ -19,19 +19,38 @@ import React from 'react';
 
 import { MenuItem } from "../../structures/ContextMenu";
 import { IEmoji } from "../../../emoji";
+import { ICustomEmoji } from '../../../emojipicker/customemoji';
+import { mediaFromMxc } from '../../../customisations/Media';
 
 interface IProps {
-    emoji: IEmoji;
+    emoji: IEmoji | ICustomEmoji;
     selectedEmojis?: Set<string>;
-    onClick(emoji: IEmoji): void;
-    onMouseEnter(emoji: IEmoji): void;
-    onMouseLeave(emoji: IEmoji): void;
+    onClick(emoji: IEmoji | ICustomEmoji): void;
+    onMouseEnter(emoji: IEmoji | ICustomEmoji): void;
+    onMouseLeave(emoji: IEmoji | ICustomEmoji): void;
 }
 
 class Emoji extends React.PureComponent<IProps> {
     render() {
         const { onClick, onMouseEnter, onMouseLeave, emoji, selectedEmojis } = this.props;
-        const isSelected = selectedEmojis && selectedEmojis.has(emoji.unicode);
+
+        let emojiElement: JSX.Element;
+        if ('unicode' in emoji) {
+            const isSelected = selectedEmojis && selectedEmojis.has(emoji.unicode);
+            emojiElement = <div className={`mx_EmojiPicker_item ${isSelected ? 'mx_EmojiPicker_item_selected' : ''}`}>
+                {emoji.unicode}
+            </div>;
+        } else {
+            const mediaUrl = mediaFromMxc(emoji.url).getThumbnailOfSourceHttp(24, 24, 'scale');
+            emojiElement = <div className="mx_EmojiPicker_item">
+                <img
+                    className="mx_customEmoji_image"
+                    src={mediaUrl}
+                    alt={emoji.shortcodes[0]} />
+            </div>
+        }
+        emojiElement;
+
         return (
             <MenuItem
                 element="li"
@@ -39,11 +58,9 @@ class Emoji extends React.PureComponent<IProps> {
                 onMouseEnter={() => onMouseEnter(emoji)}
                 onMouseLeave={() => onMouseLeave(emoji)}
                 className="mx_EmojiPicker_item_wrapper"
-                label={emoji.unicode}
+                label={'unicode' in emoji ? emoji.unicode : emoji.shortcodes[0]}
             >
-                <div className={`mx_EmojiPicker_item ${isSelected ? 'mx_EmojiPicker_item_selected' : ''}`}>
-                    { emoji.unicode }
-                </div>
+                {emojiElement}
             </MenuItem>
         );
     }

--- a/src/components/views/emojipicker/ReactionPicker.tsx
+++ b/src/components/views/emojipicker/ReactionPicker.tsx
@@ -26,6 +26,7 @@ import dis from "../../../dispatcher/dispatcher";
 import { Action } from '../../../dispatcher/actions';
 import RoomContext from "../../../contexts/RoomContext";
 import { FocusComposerPayload } from '../../../dispatcher/payloads/FocusComposerPayload';
+import { IEmoji } from '../../../emoji';
 
 interface IProps {
     mxEvent: MatrixEvent;
@@ -90,7 +91,8 @@ class ReactionPicker extends React.Component<IProps, IState> {
         });
     };
 
-    private onChoose = (reaction: string) => {
+    private onChoose = (reactionEmoji: IEmoji) => {
+        const reaction = reactionEmoji.unicode;
         this.componentWillUnmount();
         this.props.onFinished();
         const myReactions = this.getReactions();

--- a/src/components/views/rooms/EditMessageComposer.tsx
+++ b/src/components/views/rooms/EditMessageComposer.tsx
@@ -441,6 +441,8 @@ class EditMessageComposer extends React.Component<IEditMessageComposerProps, ISt
                 this.editorRef.current?.insertQuotedMessage(payload.event);
             } else if (payload.text) {
                 this.editorRef.current?.insertPlaintext(payload.text);
+            } else if (payload.emoji) {
+                this.editorRef.current?.insertEmoji(payload.emoji);
             }
         } else if (payload.action === Action.FocusEditMessageComposer) {
             this.editorRef.current.focus();

--- a/src/components/views/rooms/MessageComposer.tsx
+++ b/src/components/views/rooms/MessageComposer.tsx
@@ -53,6 +53,8 @@ import { SettingUpdatedPayload } from "../../../dispatcher/payloads/SettingUpdat
 import MessageComposerButtons from './MessageComposerButtons';
 import { ButtonEvent } from '../elements/AccessibleButton';
 import { ViewRoomPayload } from "../../../dispatcher/payloads/ViewRoomPayload";
+import { IEmoji } from '../../../emoji';
+import { ICustomEmoji } from '../../../emojipicker/customemoji';
 
 let instanceCount = 0;
 
@@ -297,10 +299,10 @@ export default class MessageComposer extends React.Component<IProps, IState> {
         }
     };
 
-    private addEmoji = (emoji: string): boolean => {
+    private addEmoji = (emoji: IEmoji | ICustomEmoji): boolean => {
         dis.dispatch<ComposerInsertPayload>({
             action: Action.ComposerInsert,
-            text: emoji,
+            emoji: emoji,
             timelineRenderingType: this.context.timelineRenderingType,
         });
         return true;

--- a/src/components/views/rooms/MessageComposerButtons.tsx
+++ b/src/components/views/rooms/MessageComposerButtons.tsx
@@ -39,9 +39,11 @@ import RoomContext from '../../../contexts/RoomContext';
 import { useDispatcher } from "../../../hooks/useDispatcher";
 import { chromeFileInputFix } from "../../../utils/BrowserWorkarounds";
 import IconizedContextMenu, { IconizedContextMenuOptionList } from '../context_menus/IconizedContextMenu';
+import { IEmoji } from '../../../emoji';
+import { ICustomEmoji } from '../../../emojipicker/customemoji';
 
 interface IProps {
-    addEmoji: (emoji: string) => boolean;
+    addEmoji: (emoji: IEmoji | ICustomEmoji) => boolean;
     haveRecording: boolean;
     isMenuOpen: boolean;
     isStickerPickerOpen: boolean;
@@ -71,7 +73,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
     let moreButtons: ReactElement[];
     if (narrow) {
         mainButtons = [
-            emojiButton(props),
+            emojiButton(props, room),
         ];
         moreButtons = [
             uploadButton(), // props passed via UploadButtonContext
@@ -82,7 +84,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
         ];
     } else if (props.collapseButtons) {
         mainButtons = [
-            emojiButton(props),
+            emojiButton(props, room),
             uploadButton(), // props passed via UploadButtonContext
         ];
         moreButtons = [
@@ -93,7 +95,7 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
         ];
     } else {
         mainButtons = [
-            emojiButton(props),
+            emojiButton(props, room),
             uploadButton(), // props passed via UploadButtonContext
             showStickersButton(props),
             voiceRecordingButton(props, narrow),
@@ -136,20 +138,22 @@ const MessageComposerButtons: React.FC<IProps> = (props: IProps) => {
     </UploadButtonContextProvider>;
 };
 
-function emojiButton(props: IProps): ReactElement {
+function emojiButton(props: IProps, room: Room): ReactElement {
     return <EmojiButton
         key="emoji_button"
         addEmoji={props.addEmoji}
         menuPosition={props.menuPosition}
+        room={room}
     />;
 }
 
 interface IEmojiButtonProps {
-    addEmoji: (unicode: string) => boolean;
+    addEmoji: (emoji: ICustomEmoji | IEmoji) => boolean;
     menuPosition: AboveLeftOf;
+    room: Room
 }
 
-const EmojiButton: React.FC<IEmojiButtonProps> = ({ addEmoji, menuPosition }) => {
+const EmojiButton: React.FC<IEmojiButtonProps> = ({ addEmoji, menuPosition, room }) => {
     const overflowMenuCloser = useContext(OverflowMenuContext);
     const [menuDisplayed, button, openMenu, closeMenu] = useContextMenu();
 
@@ -167,7 +171,7 @@ const EmojiButton: React.FC<IEmojiButtonProps> = ({ addEmoji, menuPosition }) =>
             }}
             managed={false}
         >
-            <EmojiPicker onChoose={addEmoji} showQuickReactions={true} />
+            <EmojiPicker onChoose={addEmoji} showQuickReactions={true} room={room} />
         </ContextMenu>;
     }
 

--- a/src/components/views/rooms/SendMessageComposer.tsx
+++ b/src/components/views/rooms/SendMessageComposer.tsx
@@ -531,6 +531,8 @@ export class SendMessageComposer extends React.Component<ISendMessageComposerPro
                     this.editorRef.current?.insertQuotedMessage(payload.event);
                 } else if (payload.text) {
                     this.editorRef.current?.insertPlaintext(payload.text);
+                } else if (payload.emoji) {
+                    this.editorRef.current?.insertEmoji(payload.emoji);
                 }
                 break;
         }

--- a/src/dispatcher/payloads/ComposerInsertPayload.ts
+++ b/src/dispatcher/payloads/ComposerInsertPayload.ts
@@ -19,6 +19,8 @@ import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { ActionPayload } from "../payloads";
 import { Action } from "../actions";
 import { TimelineRenderingType } from "../../contexts/RoomContext";
+import { IEmoji } from "../../emoji";
+import { ICustomEmoji } from "../../emojipicker/customemoji";
 
 export enum ComposerType {
     Send = "send",
@@ -43,8 +45,13 @@ interface IComposerInsertPlaintextPayload extends IBaseComposerInsertPayload {
     text: string;
 }
 
+interface IComposerInsertEmojiPayload extends IBaseComposerInsertPayload {
+    emoji: IEmoji | ICustomEmoji;
+}
+
 export type ComposerInsertPayload =
     IComposerInsertMentionPayload |
     IComposerInsertQuotePayload |
-    IComposerInsertPlaintextPayload;
+    IComposerInsertPlaintextPayload |
+    IComposerInsertEmojiPayload;
 

--- a/src/emojipicker/customemoji.ts
+++ b/src/emojipicker/customemoji.ts
@@ -1,0 +1,23 @@
+import { MatrixEvent } from 'matrix-js-sdk/src/matrix';
+
+export function loadImageSet(imageSetEvent: MatrixEvent): ICustomEmoji[] {
+    let loadedImages : ICustomEmoji[]= [];
+    const images = imageSetEvent.getContent().images;
+    if (!images) {
+        return;
+    }
+    for (const imageKey in images) {
+        const imageData = images[imageKey];
+        loadedImages.push({
+            shortcodes: [imageKey],
+            url: imageData.url,
+        });
+    }
+    return loadedImages;
+}
+
+export interface ICustomEmoji {
+    shortcodes: string[];
+    emoticon?: string;
+    url: string;
+}

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2262,6 +2262,7 @@
     "Zoom in": "Zoom in",
     "Zoom out": "Zoom out",
     "Frequently Used": "Frequently Used",
+    "Room Emoji": "Room Emoji",
     "Smileys & People": "Smileys & People",
     "Animals & Nature": "Animals & Nature",
     "Food & Drink": "Food & Drink",


### PR DESCRIPTION
We want to be able to pick custom room emojis with the picker, instead of
having to memorize the codes.  This change adds them into the emoji picker
and lets us send them from there.

<!-- Please describe your awesome changes here -->

-----------------------------------------------------------------------------

- [x] I agree to release my changes under this project's license


<!-- CHANGELOG_PREVIEW_START -->
---
This PR currently has no changelog labels, so will not be included in changelogs.

A reviewer can add one of: `T-Deprecation`, `T-Enhancement`, `T-Defect`, `T-Task` to indicate what type of change this is, or add `Type: [enhancement/defect/task]` to the description and I'll add them for you.<!-- CHANGELOG_PREVIEW_END -->