### PR TITLE
Do not display spoilers in message previews

### DIFF
--- a/src/Notifier.ts
+++ b/src/Notifier.ts
@@ -52,6 +52,7 @@ import ToastStore from "./stores/ToastStore";
 import { ElementCall } from "./models/Call";
 import { VoiceBroadcastChunkEventType, VoiceBroadcastInfoEventType } from "./voice-broadcast";
 import { getSenderName } from "./utils/event/getSenderName";
+import { MessageEventPreview } from "./stores/room-list/previews/MessageEventPreview";
 
 /*
  * Dispatches:
@@ -113,6 +114,15 @@ class NotifierClass {
         return TextForEvent.textForEvent(ev);
     }
 
+    private _getEventTextRepresentation(ev: MatrixEvent) {
+        const previewer = new MessageEventPreview();
+        const msg = previewer.getTextFor(ev);
+        if (msg == null) {
+            return "";
+        }
+        return msg;
+    }
+
     // XXX: exported for tests
     public displayPopupNotification(ev: MatrixEvent, room: Room): void {
         const plaf = PlatformPeg.get();
@@ -137,7 +147,7 @@ class NotifierClass {
             // notificationMessageForEvent includes sender,
             // but we already have the sender here
             if (ev.getContent().body && !msgTypeHandlers.hasOwnProperty(ev.getContent().msgtype)) {
-                msg = ev.getContent().body;
+                msg = this._getEventTextRepresentation(ev);
             }
         } else if (ev.getType() === "m.room.member") {
             // context is all in the message here, we don't need
@@ -148,7 +158,7 @@ class NotifierClass {
             // notificationMessageForEvent includes sender,
             // but we've just out sender in the title
             if (ev.getContent().body && !msgTypeHandlers.hasOwnProperty(ev.getContent().msgtype)) {
-                msg = ev.getContent().body;
+                msg = this._getEventTextRepresentation(ev);
             }
         }
 

--- a/src/Notifier.ts
+++ b/src/Notifier.ts
@@ -114,7 +114,7 @@ class NotifierClass {
         return TextForEvent.textForEvent(ev);
     }
 
-    private _getEventTextRepresentation(ev: MatrixEvent) {
+    private getEventTextRepresentation(ev: MatrixEvent): string {
         const previewer = new MessageEventPreview();
         const msg = previewer.getTextFor(ev);
         if (msg == null) {
@@ -147,7 +147,7 @@ class NotifierClass {
             // notificationMessageForEvent includes sender,
             // but we already have the sender here
             if (ev.getContent().body && !msgTypeHandlers.hasOwnProperty(ev.getContent().msgtype)) {
-                msg = this._getEventTextRepresentation(ev);
+                msg = this.getEventTextRepresentation(ev);
             }
         } else if (ev.getType() === "m.room.member") {
             // context is all in the message here, we don't need
@@ -158,7 +158,7 @@ class NotifierClass {
             // notificationMessageForEvent includes sender,
             // but we've just out sender in the title
             if (ev.getContent().body && !msgTypeHandlers.hasOwnProperty(ev.getContent().msgtype)) {
-                msg = this._getEventTextRepresentation(ev);
+                msg = this.getEventTextRepresentation(ev);
             }
         }
 

--- a/src/i18n/strings/en_EN.json
+++ b/src/i18n/strings/en_EN.json
@@ -2046,6 +2046,7 @@
     "View chat timeline": "View chat timeline",
     "Room options": "Room options",
     "Join Room": "Join Room",
+    "[spoiler]": "[spoiler]",
     "(~%(count)s results)|other": "(~%(count)s results)",
     "(~%(count)s results)|one": "(~%(count)s result)",
     "Video rooms are a beta feature": "Video rooms are a beta feature",

--- a/src/stores/room-list/previews/MessageEventPreview.ts
+++ b/src/stores/room-list/previews/MessageEventPreview.ts
@@ -21,7 +21,6 @@ import { IPreview } from "./IPreview";
 import { TagID } from "../models";
 import { _t, sanitizeForTranslation } from "../../../languageHandler";
 import { getSenderName, isSelf, shouldPrefixMessagesIn } from "./utils";
-import { getHtmlText } from "../../../HtmlUtils";
 import { stripHTMLReply, stripPlainReply } from "../../../utils/Reply";
 import { VoiceBroadcastChunkEventType } from "../../../voice-broadcast/types";
 

--- a/src/stores/room-list/previews/MessageEventPreview.ts
+++ b/src/stores/room-list/previews/MessageEventPreview.ts
@@ -61,9 +61,11 @@ export class MessageEventPreview implements IPreview {
         }
 
         if (hasHtml) {
-            const sanitised = getHtmlText(body.replace(/<br\/?>/gi, "\n")); // replace line breaks before removing them
+            const cleanedLines = body.replace(/<br\/?>/gi, "\n"); // replace line breaks before removing them
             // run it through DOMParser to fixup encoded html entities
-            body = new DOMParser().parseFromString(sanitised, "text/html").documentElement.textContent;
+            const document = new DOMParser().parseFromString(cleanedLines, "text/html").documentElement;
+            document.querySelectorAll("[data-mx-spoiler]").forEach(spoiler => spoiler.textContent = _t("[spoiler]"));
+            body = document.textContent;
         }
 
         body = sanitizeForTranslation(body);


### PR DESCRIPTION
"Message previews" means notifications and the room list preview. If there are more spots where message previews appear I can extend this function to cover those as well.

I can't test these changes properly right now because I forgot how to get a working build of SchildiChat. However, I tested this in the past and it worked perfectly! Hopefully it still works now that I've cherry-picked it 6 months into the future.

I want to get this into Element as well if it works well in Schildi.

As usual, thanks for everything!

- [x] I agree to release my changes under this project's license
