### PR TITLE
Arc/msc3971

### DIFF
--- a/src/autocomplete/Autocompleter.ts
+++ b/src/autocomplete/Autocompleter.ts
@@ -28,6 +28,7 @@ import AutocompleteProvider, { ICommand } from "./AutocompleteProvider";
 import SpaceProvider from "./SpaceProvider";
 import { TimelineRenderingType } from "../contexts/RoomContext";
 import { filterBoolean } from "../utils/arrays";
+import { ICustomEmoji } from "../emojipicker/customemoji";
 
 export interface ISelectionRange {
     beginning?: boolean; // whether the selection is in the first block of the editor or not
@@ -46,6 +47,7 @@ export interface ICompletion {
     // If provided, apply a LINK entity to the completion with the
     // data = { url: href }.
     href?: string;
+    customEmoji?: ICustomEmoji;
 }
 
 const PROVIDERS = [UserProvider, RoomProvider, EmojiProvider, NotifProvider, CommandProvider, SpaceProvider];

--- a/src/autocomplete/EmojiProvider.tsx
+++ b/src/autocomplete/EmojiProvider.tsx
@@ -103,7 +103,7 @@ export default class EmojiProvider extends AutocompleteProvider {
         // Load this room's image sets.
         const imageSetEvents = room?.currentState?.getStateEvents("im.ponies.room_emotes");
         let loadedImages: ICustomEmoji[] =
-            imageSetEvents?.flatMap((imageSetEvent) => loadImageSet(imageSetEvent)) || [];
+            imageSetEvents?.flatMap((imageSetEvent) => loadImageSet(imageSetEvent, room)) || [];
 
         // Global emotes from rooms
         const cli = MatrixClientPeg.get();
@@ -115,7 +115,7 @@ export default class EmojiProvider extends AutocompleteProvider {
                     "im.ponies.room_emotes",
                     packRoomStateKey,
                 );
-                const moreLoadedImages: ICustomEmoji[] = loadImageSet(packRoomImageSetEvents);
+                const moreLoadedImages: ICustomEmoji[] = loadImageSet(packRoomImageSetEvents, packRoom!);
                 loadedImages = [...loadedImages, ...(moreLoadedImages || [])];
             }
         }
@@ -244,6 +244,7 @@ export default class EmojiProvider extends AutocompleteProvider {
                                     <img className="mx_customEmoji_image" src={mediaUrl} alt={c.emoji.shortcodes[0]} />
                                 </PillCompletion>
                             ),
+                            customEmoji: c.emoji,
                             range: range!,
                         } as const;
                     }

--- a/src/components/views/emojipicker/EmojiPicker.tsx
+++ b/src/components/views/emojipicker/EmojiPicker.tsx
@@ -76,7 +76,7 @@ class EmojiPicker extends React.Component<IProps, IState> {
         let loadedImages: ICustomEmoji[];
         if (props.room) {
             const imageSetEvents = props.room.currentState.getStateEvents("im.ponies.room_emotes");
-            loadedImages = imageSetEvents.flatMap((imageSetEvent) => loadImageSet(imageSetEvent));
+            loadedImages = imageSetEvents.flatMap((imageSetEvent) => loadImageSet(imageSetEvent, props.room));
         } else {
             loadedImages = [];
         }

--- a/src/components/views/messages/TextualBody.tsx
+++ b/src/components/views/messages/TextualBody.tsx
@@ -439,6 +439,13 @@ export default class TextualBody extends React.Component<IBodyProps, IState> {
         let target: HTMLLinkElement | null = e.target as HTMLLinkElement;
         // links processed by linkifyjs have their own handler so don't handle those here
         if (target.classList.contains(linkifyOpts.className as string)) return;
+        // handle clicking packs
+        const packUrl = target.getAttribute("data-mx-pack-url");
+        if (packUrl) {
+            // it could be converted to a localHref -> therefore handle locally
+            e.preventDefault();
+            window.location.hash = tryTransformPermalinkToLocalHref(packUrl);
+        }
         if (target.nodeName !== "A") {
             // Jump to parent as the `<a>` may contain children, e.g. an anchor wrapping an inline code section
             target = target.closest<HTMLLinkElement>("a");

--- a/src/components/views/rooms/BasicMessageComposer.tsx
+++ b/src/components/views/rooms/BasicMessageComposer.tsx
@@ -900,7 +900,7 @@ export default class BasicMessageEditor extends React.Component<IProps, IState> 
         if ("unicode" in emoji) {
             emojiPart = partCreator.emoji(emoji.unicode);
         } else {
-            emojiPart = partCreator.customEmoji(emoji.shortcodes[0], emoji.url);
+            emojiPart = partCreator.customEmoji(emoji.shortcodes[0], emoji.url, emoji.roomId, emoji.eventId);
         }
         model.transform(() => {
             const addedLen = model.insert([emojiPart], position);

--- a/src/editor/autocomplete.ts
+++ b/src/editor/autocomplete.ts
@@ -112,7 +112,14 @@ export default class AutocompleteWrapperModel {
                 // command needs special handling for auto complete, but also renders as plain texts
                 return [(this.partCreator as CommandPartCreator).command(text)];
             case "customEmoji":
-                return [this.partCreator.customEmoji(text, completionId)];
+                return [
+                    this.partCreator.customEmoji(
+                        text,
+                        completionId!,
+                        completion.customEmoji?.roomId,
+                        completion.customEmoji?.eventId,
+                    ),
+                ];
             default:
                 // used for emoji and other plain text completion replacement
                 return this.partCreator.plainWithEmoji(text);

--- a/src/editor/deserialize.ts
+++ b/src/editor/deserialize.ts
@@ -19,11 +19,12 @@ import { MatrixEvent } from "matrix-js-sdk/src/models/event";
 import { MsgType } from "matrix-js-sdk/src/@types/event";
 
 import { checkBlockNode } from "../HtmlUtils";
-import { getPrimaryPermalinkEntity } from "../utils/permalinks/Permalinks";
+import { getPrimaryPermalinkEntity, parsePermalink } from "../utils/permalinks/Permalinks";
 import { Part, PartCreator, Type } from "./parts";
 import SdkConfig from "../SdkConfig";
 import { textToHtmlRainbow } from "../utils/colour";
 import { stripPlainReply } from "../utils/Reply";
+import { PermalinkParts } from "../utils/permalinks/PermalinkConstructor";
 
 const LIST_TYPES = ["UL", "OL", "LI"];
 
@@ -97,7 +98,13 @@ function parseImage(n: Node, pc: PartCreator, opts: IParseOptions): Part[] {
     const isCustomEmoji = elm.hasAttribute("data-mx-emoticon");
     if (isCustomEmoji) {
         const shortcode = elm.title || elm.alt || ":SHORTCODE_MISSING:";
-        return [pc.customEmoji(shortcode, src)];
+        // parse the link
+        const packUrl = elm.getAttribute("data-mx-pack-url");
+        let permalinkParts: PermalinkParts | null = null;
+        if (packUrl) {
+            permalinkParts = parsePermalink(packUrl);
+        }
+        return [pc.customEmoji(shortcode, src, permalinkParts?.roomIdOrAlias, permalinkParts?.eventId)];
     }
     return pc.plainWithEmoji(`![${escape(alt)}](${src})`);
 }

--- a/src/editor/serialize.ts
+++ b/src/editor/serialize.ts
@@ -21,11 +21,11 @@ import escapeHtml from "escape-html";
 import _ from "lodash";
 
 import Markdown from "../Markdown";
-import { makeGenericPermalink } from "../utils/permalinks/Permalinks";
+import { makeGenericPermalink, makeRoomPermalink } from "../utils/permalinks/Permalinks";
 import EditorModel from "./model";
 import SettingsStore from "../settings/SettingsStore";
 import SdkConfig from "../SdkConfig";
-import { Type } from "./parts";
+import { ICustomEmojiPart, Type } from "./parts";
 
 export function mdSerialize(model: EditorModel): string {
     return model.parts.reduce((html, part) => {
@@ -53,6 +53,18 @@ export function mdSerialize(model: EditorModel): string {
                     `[${part.text.replace(/[[\\\]]/g, (c) => "\\" + c)}](${makeGenericPermalink(part.resourceId)})`
                 );
             case Type.CustomEmoji:
+                if ((part as ICustomEmojiPart).roomId) {
+                    const permalink = makeRoomPermalink(
+                        (part as ICustomEmojiPart).roomId!,
+                        (part as ICustomEmojiPart).eventId,
+                    );
+                    return (
+                        html +
+                        `<img data-mx-emoticon height="18" src="${encodeURI(part.resourceId)}"` +
+                        ` data-mx-pack-url="${permalink}"` +
+                        ` title=":${_.escape(part.text)}:" alt=":${_.escape(part.text)}:">`
+                    );
+                }
                 return (
                     html +
                     `<img data-mx-emoticon height="32" src="${encodeURI(part.resourceId)}"` +

--- a/src/emojipicker/customemoji.ts
+++ b/src/emojipicker/customemoji.ts
@@ -14,19 +14,27 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import { MatrixEvent } from "matrix-js-sdk/src/matrix";
+import { JoinRule, MatrixEvent, Room } from "matrix-js-sdk/src/matrix";
 
-export function loadImageSet(imageSetEvent: MatrixEvent): ICustomEmoji[] {
+export function loadImageSet(imageSetEvent: MatrixEvent, room?: Room): ICustomEmoji[] {
     const loadedImages: ICustomEmoji[] = [];
     const images = imageSetEvent?.getContent().images;
+    let eventId: string | undefined;
+    let roomId: string | undefined;
     if (!images) {
         return [];
+    }
+    if (room?.getJoinRule() === JoinRule.Public) {
+        eventId = imageSetEvent?.getId();
+        roomId = room?.roomId;
     }
     for (const imageKey in images) {
         const imageData = images[imageKey];
         loadedImages.push({
             shortcodes: [imageKey],
             url: imageData.url,
+            roomId: roomId,
+            eventId: eventId,
         });
     }
     return loadedImages;
@@ -36,4 +44,6 @@ export interface ICustomEmoji {
     shortcodes: string[];
     emoticon?: string;
     url: string;
+    roomId?: string;
+    eventId?: string;
 }

--- a/src/utils/permalinks/Permalinks.ts
+++ b/src/utils/permalinks/Permalinks.ts
@@ -284,23 +284,32 @@ export function makeUserPermalink(userId: string): string {
     return getPermalinkConstructor().forUser(userId);
 }
 
-export function makeRoomPermalink(roomId: string): string {
+export function makeRoomPermalink(roomId: string, eventId?: string): string {
     if (!roomId) {
         throw new Error("can't permalink a falsy roomId");
     }
 
     // If the roomId isn't actually a room ID, don't try to list the servers.
     // Aliases are already routable, and don't need extra information.
-    if (roomId[0] !== "!") return getPermalinkConstructor().forRoom(roomId, []);
+    if (roomId[0] !== "!")
+        return eventId
+            ? getPermalinkConstructor().forEvent(roomId, eventId!, [])
+            : getPermalinkConstructor().forRoom(roomId, []);
 
     const client = MatrixClientPeg.get();
     const room = client.getRoom(roomId);
     if (!room) {
-        return getPermalinkConstructor().forRoom(roomId, []);
+        return eventId
+            ? getPermalinkConstructor().forEvent(roomId, eventId!, [])
+            : getPermalinkConstructor().forRoom(roomId, []);
     }
     const permalinkCreator = new RoomPermalinkCreator(room);
     permalinkCreator.load();
-    return permalinkCreator.forShareableRoom();
+    if (eventId) {
+        return permalinkCreator.forEvent(eventId);
+    } else {
+        return permalinkCreator.forShareableRoom();
+    }
 }
 
 export function isPermalinkHost(host: string): boolean {


### PR DESCRIPTION
Fresh delivery for https://github.com/matrix-org/matrix-spec-proposals/pull/3971

Does the following:
* sends emoji with the new attribute
* makes the emoji clickable and links to the correct room

This doesn't implement any advanced UI for after clicking the link, but does send the user to the correct room.  A future change will be to show the user a big red button to add the pack.


---

-   [x] I agree to release my changes under this project's license
