### PR TITLE
Implement showing and sending media spoilers

### DIFF
--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -498,7 +498,7 @@ export default class ContentMessages {
 
         // Attach content warning
         if (contentWarning) {
-            content["m.content_warning"] = {
+            content["town.robin.msc3725.content_warning"] = {
                 type: "m.spoiler" // Since the UI checkbox is labelled "Spoiler"
             }
         }

--- a/src/ContentMessages.ts
+++ b/src/ContentMessages.ts
@@ -415,6 +415,7 @@ export default class ContentMessages {
         for (let i = 0; i < okFiles.length; ++i) {
             const file = okFiles[i];
             const loopPromiseBefore = promBefore;
+            let shouldContentWarning = false;
 
             if (!uploadAll) {
                 const { finished } = Modal.createDialog(UploadConfirmDialog, {
@@ -422,7 +423,8 @@ export default class ContentMessages {
                     currentIndex: i,
                     totalFiles: okFiles.length,
                 });
-                const [shouldContinue, shouldUploadAll] = await finished;
+                const [shouldContinue, shouldUploadAll, contentWarning] = await finished;
+                shouldContentWarning = contentWarning;
                 if (!shouldContinue) break;
                 if (shouldUploadAll) {
                     uploadAll = true;
@@ -436,6 +438,7 @@ export default class ContentMessages {
                     relation,
                     matrixClient,
                     replyToEvent ?? undefined,
+                    shouldContentWarning,
                     loopPromiseBefore,
                 ),
             );
@@ -481,6 +484,7 @@ export default class ContentMessages {
         relation: IEventRelation | undefined,
         matrixClient: MatrixClient,
         replyToEvent: MatrixEvent | undefined,
+        contentWarning?: boolean,
         promBefore?: Promise<any>,
     ): Promise<void> {
         const fileName = file.name || _t("Attachment");
@@ -491,6 +495,13 @@ export default class ContentMessages {
             },
             msgtype: MsgType.File, // set more specifically later
         };
+
+        // Attach content warning
+        if (contentWarning) {
+            content["m.content_warning"] = {
+                type: "m.spoiler" // Since the UI checkbox is labelled "Spoiler"
+            }
+        }
 
         // Attach mentions, which really only applies if there's a replyToEvent.
         attachMentions(matrixClient.getSafeUserId(), content, null, replyToEvent);

--- a/src/components/views/dialogs/UploadConfirmDialog.tsx
+++ b/src/components/views/dialogs/UploadConfirmDialog.tsx
@@ -22,16 +22,21 @@ import { _t } from "../../../languageHandler";
 import { getBlobSafeMimeType } from "../../../utils/blobs";
 import BaseDialog from "./BaseDialog";
 import DialogButtons from "../elements/DialogButtons";
+import StyledCheckbox from "../elements/StyledCheckbox";
 import { fileSize } from "../../../utils/FileUtils";
 
 interface IProps {
     file: File;
     currentIndex: number;
     totalFiles: number;
-    onFinished: (uploadConfirmed: boolean, uploadAll?: boolean) => void;
+    onFinished: (uploadConfirmed: boolean, uploadAll?: boolean, contentWarning?: boolean) => void;
 }
 
-export default class UploadConfirmDialog extends React.Component<IProps> {
+interface IState {
+    isContentWarning: boolean;
+}
+
+export default class UploadConfirmDialog extends React.Component<IProps, IState> {
     private readonly objectUrl: string;
     private readonly mimeType: string;
 
@@ -48,10 +53,18 @@ export default class UploadConfirmDialog extends React.Component<IProps> {
         this.mimeType = getBlobSafeMimeType(props.file.type);
         const blob = new Blob([props.file], { type: this.mimeType });
         this.objectUrl = URL.createObjectURL(blob);
+
+        this.state = {
+            isContentWarning: false,
+        }
     }
 
     public componentWillUnmount(): void {
         if (this.objectUrl) URL.revokeObjectURL(this.objectUrl);
+    }
+
+    private toggleContentWarning = (): void => {
+        this.setState({ isContentWarning: !this.state.isContentWarning });
     }
 
     private onCancelClick = (): void => {
@@ -59,11 +72,11 @@ export default class UploadConfirmDialog extends React.Component<IProps> {
     };
 
     private onUploadClick = (): void => {
-        this.props.onFinished(true);
+        this.props.onFinished(true, false, this.state.isContentWarning);
     };
 
     private onUploadAllClick = (): void => {
-        this.props.onFinished(true, true);
+        this.props.onFinished(true, true, this.state.isContentWarning);
     };
 
     public render(): React.ReactNode {
@@ -121,6 +134,10 @@ export default class UploadConfirmDialog extends React.Component<IProps> {
                         </div>
                     </div>
                 </div>
+
+                <StyledCheckbox checked={this.state.isContentWarning} onChange={() => this.toggleContentWarning()}>
+                    Spoiler
+                </StyledCheckbox>
 
                 <DialogButtons
                     primaryButton={_t("Upload")}

--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -83,13 +83,12 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
             imgError: false,
             imgLoaded: false,
             hover: false,
-            showImage: SettingsStore.getValue("showImages"),
+            showImage: SettingsStore.getValue("showImages") && !this.props.mxEvent.getContent()["m.content_warning"],
             placeholder: Placeholder.NoImage,
         };
     }
 
     protected showImage(): void {
-        localStorage.setItem("mx_ShowImage_" + this.props.mxEvent.getId(), "true");
         this.setState({ showImage: true });
         this.downloadImage();
     }
@@ -338,13 +337,16 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
         this.unmounted = false;
 
         const showImage =
-            this.state.showImage || localStorage.getItem("mx_ShowImage_" + this.props.mxEvent.getId()) === "true";
+            this.state.showImage;
 
         if (showImage) {
             // noinspection JSIgnoredPromiseFromCall
             this.downloadImage();
             this.setState({ showImage: true });
-        } // else don't download anything because we don't want to display anything.
+        } else {
+            // don't download anything because we don't want to display anything.
+            this.setState({ contentUrl: this.getContentUrl() }); // doing this ensures wrapImage() gets called later, which adds the needed onClick handler
+        }
 
         // Add a 150ms timer for blurhash to first appear.
         if (this.props.mxEvent.getContent().info?.[BLURHASH_FIELD]) {

--- a/src/components/views/messages/MImageBody.tsx
+++ b/src/components/views/messages/MImageBody.tsx
@@ -83,7 +83,7 @@ export default class MImageBody extends React.Component<IBodyProps, IState> {
             imgError: false,
             imgLoaded: false,
             hover: false,
-            showImage: SettingsStore.getValue("showImages") && !this.props.mxEvent.getContent()["m.content_warning"],
+            showImage: SettingsStore.getValue("showImages") && !this.props.mxEvent.getContent()["town.robin.msc3725.content_warning"],
             placeholder: Placeholder.NoImage,
         };
     }

--- a/src/components/views/messages/MVideoBody.tsx
+++ b/src/components/views/messages/MVideoBody.tsx
@@ -177,7 +177,7 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
                         decryptedUrl: `data:${mimetype},`,
                         decryptedThumbnailUrl: thumbnailUrl || `data:${mimetype},`,
                         decryptedBlob: null,
-                        showVideo: !content?.["m.content_warning"],
+                        showVideo: !content?.["town.robin.msc3725.content_warning"],
                     });
                 }
             } catch (err) {
@@ -190,7 +190,7 @@ export default class MVideoBody extends React.PureComponent<IBodyProps, IState> 
         } else { // not encrypted
             const content = this.props.mxEvent.getContent<IMediaEventContent>();
             this.setState({
-                showVideo: !content?.["m.content_warning"],
+                showVideo: !content?.["town.robin.msc3725.content_warning"],
             })
         }
     }


### PR DESCRIPTION
For sending, there is a checkbox during file upload asking whether to send as a spoiler. It applies to both "upload" and "upload all".

For showing, we piggyback off the existing hidden images implementation, fixing it to actually function correctly and be clickable. It works for m.image and m.video events. I have not tried using it when the base event is an extensible event.

Both of these use the `town.robin.msc3725.content_warning` (later, `m.content_warning`) event type as per [MSC3725](https://github.com/matrix-org/matrix-spec-proposals/pull/3725).

The previous hidden images implementation would PERMANENTLY remember an image as "should be shown" after it has been clicked once. I removed this behaviour, since the status quo on other apps of forgetting the state after you click to another room seems fairly natural. And it gives you a natural way out if you regret clicking.

If merged upstream, this could fix vector-im/element-web#18061 and vector-im/element-web#18062.

![image](https://github.com/SchildiChat/matrix-react-sdk/assets/28467304/4c51ed53-c348-4d6c-a489-8ed6588c455a)

![image](https://github.com/SchildiChat/matrix-react-sdk/assets/28467304/edec0a36-f60d-4fe7-a928-13ed4756ac3b)


-   [x] I agree to release my changes under this project's license
