### PR TITLE
Reset the scroll bar width from `thin` to the default value

### DIFF
--- a/res/css/_components.pcss
+++ b/res/css/_components.pcss
@@ -382,3 +382,6 @@
 @import "./voice-broadcast/atoms/_VoiceBroadcastRecordingConnectionError.pcss";
 @import "./voice-broadcast/atoms/_VoiceBroadcastRoomSubtitle.pcss";
 @import "./voice-broadcast/molecules/_VoiceBroadcastBody.pcss";
+
+/* TODO: replace with a CSS file, on which custom CSS properties are collectively specified. */
+@import "./_sc/feature-improvement/structures/_AutoHideScrollbar.pcss";

--- a/res/css/_sc/feature-improvement/structures/_AutoHideScrollbar.pcss
+++ b/res/css/_sc/feature-improvement/structures/_AutoHideScrollbar.pcss
@@ -1,0 +1,19 @@
+/*
+Copyright 2024 Suguru Hirahara
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+* {
+    scrollbar-width: initial; /* Reset to the default value. See: https://github.com/SchildiChat/schildichat-desktop/issues/238 */
+}


### PR DESCRIPTION
Fixes https://github.com/SchildiChat/schildichat-desktop/issues/238

This PR intends to reset the scroll bar width from `thin` to the default value in order to improve UX.

It also intends to present itself as a proof of concept of https://github.com/SchildiChat/matrix-react-sdk/pull/23 (create a slim base, on which bug fixes, customization, experiments and so on can be appended).

**Before:**

[before.webm](https://github.com/SchildiChat/matrix-react-sdk/assets/3362943/aad636fc-4408-496d-9135-170ec93843b3)

**After:**

[after.webm](https://github.com/SchildiChat/matrix-react-sdk/assets/3362943/2343993f-a1aa-4853-bf56-11a5b9b83c85)


Signed-off-by: Suguru Hirahara <luixxiul@users.noreply.github.com>

---

-   [x] I agree to release my changes under this project's license
